### PR TITLE
Force bin/isml-linter.js to be LF instead of CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bin/isml-linter.js text eol=lf


### PR DESCRIPTION
It will fix the issue #35 that happens when running the ISML Linter v5.40.0 / v5.40.1 using `yarn` on Linux/Mac